### PR TITLE
Use style.textContent

### DIFF
--- a/src/blobject-fit.js
+++ b/src/blobject-fit.js
@@ -73,11 +73,7 @@
 			head = document.head || document.getElementsByTagName('head')[0],
 			style = document.createElement('style');
 
-		style.type = 'text/css';
-		if(style.styleSheet)
-			style.styleSheet.cssText = css;
-		else
-			style.appendChild(document.createTextNode(css));
+		style.textContent = css;
 
 		head.appendChild(style);
 


### PR DESCRIPTION
- `style.type = 'text/css';` is the default value
- `style.textContent` is supported in IE9 as the standard way to set its content

https://developer.mozilla.org/en/docs/Web/API/Node/textContent#Browser_compatibility